### PR TITLE
Add jabbawocky/statuscraft — service status monitoring MCP (141 services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ AWS also provides a [Prometheus MCP Server](https://awslabs.github.io/mcp/server
 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | Dynatrace monitoring integration. |
 | [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) | Last9 observability. |
 | [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) | Uptime monitoring — 10 tools for monitor/incident management. Remote MCP (OAuth 2.0) + stdio. |
+| [jabbawocky/statuscraft](https://github.com/jabbawocky/statuscraft) | Service status monitoring — 141 services covered (AWS, GitHub, Vercel, Stripe, Cloudflare, and more). Ask your AI assistant if a service is down before debugging your own code. Local stdio, no API key. |
 
 ## 🔒 Security
 


### PR DESCRIPTION
## What

Adds [StatusCraft](https://github.com/jabbawocky/statuscraft) to the **APM & Monitoring** section of the Observability category.

## Why it fits

StatusCraft monitors the live status of 141 popular SaaS services (AWS, GitHub, Vercel, Stripe, Cloudflare, Linear, Notion, and more) by reading their official status pages via MCP.

**DevOps use case:** Before spending time debugging infrastructure issues, ask your AI assistant "is AWS us-east-1 having issues right now?" — StatusCraft gives you the answer in seconds, directly from the source.

**Key details:**
- 141 services covered across cloud, CDN, payments, CI/CD, database, and dev tool categories
- No API key required — reads official status pages
- Local stdio transport (runs via `npx -y github:jabbawocky/statuscraft`)
- MIT license
- TypeScript