### PR TITLE
Add ax to coding agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Tools for executing commands or interacting with local environments safely.
 | [doggybee/mcp-server-leetcode](https://github.com/doggybee/mcp-server-leetcode) | LeetCode problem access. |
 | [jinzcdev/leetcode-mcp-server](https://github.com/jinzcdev/leetcode-mcp-server) | LeetCode (global/China) access. |
 | [willibrandon/CursorMCPMonitor](https://github.com/willibrandon/CursorMCPMonitor) | MCP monitoring for Cursor. |
+| [Necmttn/ax](https://github.com/Necmttn/ax) | Local telemetry and cost analytics for AI coding-agent sessions, tools, and skills. |
 | [SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory) | Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context. VSCode extension + CLI + MCP server. |
 | [claw-army/claude-node](https://github.com/claw-army/claude-node) | Python subprocess bridge for Claude Code CLI. |
 | [HendryAvila/Hoofy](https://github.com/HendryAvila/Hoofy) | Spec-driven dev companion with persistent memory, adaptive change pipeline, and Clarity Gate. 32 tools, single Go binary. |


### PR DESCRIPTION
Adds ax to the Coding Agents section.

ax fits this list because it exposes local MCP queries over AI coding-agent telemetry, including sessions, tool usage, skill usage, and cost analytics.

Validation: confirmed the added GitHub link returns 200.

---

_Generated with [ax](https://github.com/Necmttn/ax)._