### PR TITLE
Add Project Telos DevOps visibility tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ GitOps deployment management via AI.
 
 | Repo | Notes |
 |------|-------|
+| [HarperZ9/telos](https://github.com/HarperZ9/telos) | Local-first MCP/CLI workbench for inspectable DevOps agent workflows: workspace maps, CI triage, action receipts, context packs, and operator verification doctors. |
 | [SBDI/mcp-devps-hub](https://github.com/SBDI/mcp-devps-hub) | End-to-end DevOps visibility. |
 | [gofireflyio/firefly-mcp](https://github.com/gofireflyio/firefly-mcp) | Cloud resource discovery and codification. |
 


### PR DESCRIPTION
Adds Project Telos to this DevOps MCP visibility list as a local-first MCP/CLI workbench for inspectable AI-assisted development and operations.

Project Telos exposes source-checkout MCP surfaces and local verification workflows for source provenance, workspace maps, routing ledgers, action receipts, context packs, CI/operator doctors, and MATCH/DRIFT/UNVERIFIABLE review packets.

Validation:
- git diff --check
- rg Project Telos / HarperZ9/telos in README.md
- Native Telos operator doctor in this outreach session reports MATCH, 14/14 checks, and 70 available MCP tools across Gather, Index, Forum, Crucible, and Telos.
