### PR TITLE
Add gcontext MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Vulnerability scanning directly from your AI assistant.
 | [slouchd/cyberchef-api-mcp-server](https://github.com/slouchd/cyberchef-api-mcp-server) | CyberChef API access. |
 | [nickpending/mcp-recon](https://github.com/nickpending/mcp-recon) | Recon + domain analysis. |
 | [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) | AES-256-GCM + Argon2id encrypted vault. Resolves `{{PLACEHOLDER}}` secrets so API keys never appear in prompts. |
+| [bleak-ai/gcontext](https://github.com/bleak-ai/gcontext) | Secure agent execution: secret values never leave your machine, structure syncs to cloud. Typed workspace with split secrets. `uvx gcontext-mcp`. |
 
 ## 📝 Collaboration
 


### PR DESCRIPTION
Add [gcontext](https://github.com/bleak-ai/gcontext) to Community Security Servers.

Secure agent execution: secret values never leave your machine, structure syncs to cloud. Typed workspace with split secrets.

- **Install**: `uvx gcontext-mcp`
- **License**: MIT
- **Free**, self-hostable