### PR TITLE
Add Find MCP to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Tools for executing commands or interacting with local environments safely.
 | [Arch Tools](https://archtools.dev) | 53 production-ready AI tools via MCP with x402 USDC payments. |
 | [Not Human Search](https://nothumansearch.ai/mcp) | Search engine indexing 1,900+ agent-first tools (MCP servers, OpenAPI, llms.txt). Tools for `search_sites`, `verify_mcp` (live JSON-RPC probe), `list_categories`, and more. |
 | [The Stall](https://the-stall.intuitek.ai/mcp) | 208 pay-per-call data capabilities via x402 USDC micropayments — market intel, crypto/DeFi analytics, infrastructure probes, financial data, and more. No API keys. |
+| [Find MCP](https://github.com/agentage/find-mcp) | Search 17,000+ MCP servers from the official MCP registry, remote (Streamable HTTP, catalog.agentage.io/mcp) or stdio (npx @agentage/find-mcp), no auth needed for search. |
 
 ## 🚀 CI/CD
 


### PR DESCRIPTION
Adds Find MCP to the Aggregators table (one row, matching the "Not Human Search" / "The Stall" entries).

- Repo: https://github.com/agentage/find-mcp
- npm: `@agentage/find-mcp` (stdio: `npx -y @agentage/find-mcp`)
- Remote: Streamable HTTP `https://catalog.agentage.io/mcp` (no auth needed for search)
- Web UI: https://catalog.agentage.io/mcp

DevOps relevance: searches the agentage MCP Catalog (17,000+ servers synced from the official MCP registry, registry.modelcontextprotocol.io), letting agents discover infra/CI/monitoring MCP servers across the full catalog rather than relying on a curated list alone.

Disclosure: I maintain Find MCP.
