### PR TITLE
Add ghost-in-the-droid — Android/iOS device control for mobile CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,16 @@ GitOps deployment management via AI.
 | **Maintainer** | 👥 Community |
 | **What it does** | Mobile CI/CD pipeline control. |
 
+### Ghost in the Droid (Android/iOS Device Control)
+
+| | |
+|---|---|
+| **Repo** | [ghost-in-the-droid/android-agent](https://github.com/ghost-in-the-droid/android-agent) |
+| **Maintainer** | 👥 Community |
+| **Install** | `pip install ghost-in-the-droid` |
+| **What it does** | Give any LLM agent a real Android or iPhone as its body. 62 MCP tools: tap, swipe, screenshot, screen-tree reading, app launch, on-device inference (llama.cpp/MediaPipe/MLX). Docker+KVM emulator pools for Android device farms in CI/CD pipelines. |
+| **Transports** | 📡 stdio |
+
 ### DevOps Visibility
 
 | Repo | Notes |


### PR DESCRIPTION
## Summary

[Ghost in the Droid](https://github.com/ghost-in-the-droid/android-agent) adds 62 MCP tools for real Android and iOS device control — a strong fit alongside Codemagic in the Mobile CI/CD section.

**DevOps-relevant capabilities:**
- Docker+KVM emulator pools → spin up Android device farms in CI/CD pipelines
- 62 tools: tap, swipe, screenshot, screen-tree, app install/launch/uninstall, adb shell
- On-device inference: llama.cpp, MediaPipe, MLX
- iOS via WebDriverAgent

`pip install ghost-in-the-droid`

- GitHub: https://github.com/ghost-in-the-droid/android-agent
- PyPI: https://pypi.org/project/ghost-in-the-droid/