### PR TITLE
Add API Status Check MCP to APM & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ AWS also provides a [Prometheus MCP Server](https://awslabs.github.io/mcp/server
 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | Dynatrace monitoring integration. |
 | [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) | Last9 observability. |
 | [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) | Uptime monitoring — 10 tools for monitor/incident management. Remote MCP (OAuth 2.0) + stdio. |
+| [API Status Check](https://apistatuscheck.com/mcp) | Status of 62 *third-party* APIs your stack depends on (OpenAI, Stripe, AWS, GitHub…) — 6 tools incl. `list_down_apis` and `get_uptime_history`. Hosted remote MCP, no auth. |
 
 ## 🔒 Security
 

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ AWS also provides a [Prometheus MCP Server](https://awslabs.github.io/mcp/server
 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | Dynatrace monitoring integration. |
 | [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) | Last9 observability. |
 | [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) | Uptime monitoring — 10 tools for monitor/incident management. Remote MCP (OAuth 2.0) + stdio. |
-| [API Status Check](https://apistatuscheck.com/mcp) | Status of 62 *third-party* APIs your stack depends on (OpenAI, Stripe, AWS, GitHub…) — 6 tools incl. `list_down_apis` and `get_uptime_history`. Hosted remote MCP, no auth. |
+| [API Status Check](https://apistatuscheck.com/mcp) | Status of 285 *third-party* APIs your stack depends on (OpenAI, Stripe, AWS, GitHub…) — 6 tools incl. `list_down_apis` and `get_uptime_history`. Hosted remote MCP, no auth. |
 
 ## 🔒 Security
 


### PR DESCRIPTION
One row in **Observability → APM & Monitoring**.

**What it does:** every entry in that section monitors *your own* stack — Grafana, Prometheus, Datadog, Dynatrace, Uptrack. This one covers the other half of an incident: whether the third-party API you depend on is the thing that broke. 62 providers (OpenAI, Anthropic, Stripe, AWS, GitHub, Twilio, Cloudflare…), 6 tools:

- `list_down_apis` — everything currently degraded or down, in one call
- `get_api_status` / `get_uptime_history` — per-provider current state and history
- `search_apis` / `list_apis` / `list_categories` — resolve a product name to a slug

Useful during triage: an agent can ask "is this us or upstream?" before anyone reads a dashboard.

**Against your requirements:**
- *Working public link* — [apistatuscheck.com/mcp](https://apistatuscheck.com/mcp) (docs, 200). Hosted remote MCP at `https://apistatuscheck.com/api/mcp`, streamable HTTP, **no auth or signup** — `tools/list` answers over plain curl.
- *DevOps relevance* — monitoring / incident triage.
- *Active maintenance* — monitors run hourly; the service is live now.

**Disclosure:** I run API Status Check. Linking the docs page rather than a repo — the server is hosted, not distributed as source. If the list is repo-only, close this and no hard feelings.