### PR TITLE
Add Palisade DMARC Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,18 @@ Vulnerability scanning directly from your AI assistant.
 | **What it does** | 🔍 Static analysis, OWASP scanning, custom rule execution. |
 | **Remote** | 🌐 `https://mcp.semgrep.ai` (no auth required). |
 
+### Palisade
+
+Email-authentication security and remediation for domains.
+
+| | |
+|---|---|
+| **Repo** | [palisadeemail/palisade-mcp](https://github.com/palisadeemail/palisade-mcp) |
+| **Docs** | [Palisade developer guide](https://developer.palisade.email/docs/guide) |
+| **Maintainer** | 🏷️ Palisade (Official) |
+| **What it does** | 🛡️ Manage DMARC, SPF, DKIM, BIMI, MTA-STS, DNS records, domain verification, and remediation tasks. |
+| **Access** | 💻 `npx -y @palisadeemail/mcp` with `PALISADE_API_KEY`; remote Streamable HTTP endpoint at `https://api.palisade.email/mcp` with Bearer authentication. |
+
 ### Community Security Servers
 
 | Repo | Notes |


### PR DESCRIPTION
Adds Palisade to the Security section.

Palisade provides AI-agent access to DMARC, SPF, DKIM, BIMI, MTA-STS, DNS records, domain verification, and remediation tasks.

- Source: https://github.com/palisadeemail/palisade-mcp
- Docs: https://developer.palisade.email/docs/guide
- Package: https://www.npmjs.com/package/@palisadeemail/mcp

No credentials are included.