### PR TITLE
Add agent-qa to browser automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Tools for executing commands or interacting with local environments safely.
 | [scrapeless-ai/scrapeless-mcp-server](https://github.com/scrapeless-ai/scrapeless-mcp-server) | SERP and web data access. |
 | [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) | Browser automation server. |
 | [autonomous-testing/wopee-mcp](https://www.npmjs.com/package/wopee-mcp) | AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status. |
+| [vostride/agent-qa](https://github.com/vostride/agent-qa) | Natural-language web and mobile regression testing through MCP with persistent memory and self-healing execution. |
 
 ## ⚙️ Code Execution
 


### PR DESCRIPTION
## Summary

Adds agent-qa to **Browser Automation** as an MCP-enabled QA toolkit for natural-language web and mobile regression tests.

The entry follows the existing two-column table format and distinguishes agent-qa through persistent execution memory and self-healing runs. The project also provides a dashboard, CLI, and Agent Skills for agent-driven QA workflows.

## Validation

- The public repository, documentation, and license links return HTTP 200.
- The project was not already listed or proposed.
- Table formatting and `git diff --check` pass.

Project disclosure: this submission is for agent-qa itself. Its current FSL-1.1-ALv2 license converts to Apache-2.0 after two years.
