### PR TITLE
Use canonical Palisade MCP documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ Email-authentication security and remediation for domains.
 | | |
 |---|---|
 | **Repo** | [palisadeemail/palisade-mcp](https://github.com/palisadeemail/palisade-mcp) |
-| **Docs** | [Palisade developer guide](https://developer.palisade.email/docs/guide) |
+| **Docs** | [Palisade MCP](https://www.palisade.email/mcp) |
 | **Maintainer** | 🏷️ Palisade (Official) |
 | **What it does** | 🛡️ Manage DMARC, SPF, DKIM, BIMI, MTA-STS, DNS records, domain verification, and remediation tasks. |
 | **Access** | 💻 `npx -y @palisadeemail/mcp` with `PALISADE_API_KEY`; remote Streamable HTTP endpoint at `https://api.palisade.email/mcp` with Bearer authentication. |


### PR DESCRIPTION
## Summary\n\nReplace the legacy Palisade developer-guide URL with the canonical MCP product page.\n\n- canonical page: https://www.palisade.email/mcp\n- repository and endpoint remain unchanged\n\nThis is a documentation-only follow-up to #67.