### PR TITLE
Add 404.directory to aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Tools for executing commands or interacting with local environments safely.
 
 | Repo | Notes |
 |------|-------|
+| [404.directory](https://github.com/MM-sheng/404-directory) | Public read-only MCP with 12 tools for current official cloud/AI documentation, structured deployment verification, and trust-scored tool discovery. No account or API key; remote Streamable HTTP or identity-preserving install: `npx -y @mmvv1638/404-directory-mcp --source awesome-mcp-devops`. |
 | [askbudi/roundtable](https://github.com/askbudi/roundtable) | Multi-assistant MCP hub. |
 | [composiohq/rube](https://github.com/composiohq/rube) | 500+ app integrations. |
 | [julien040/anyquery](https://github.com/julien040/anyquery) | SQL over 40+ apps. |


### PR DESCRIPTION
Adds 404.directory to the Aggregators section.

DevOps relevance:
- `verify_web` independently checks public release status, HTTPS, redirects, and version-specific text
- `search_official_docs` searches current OpenAI, Microsoft Learn, AWS, and Cloudflare documentation
- discovery tools compare MCP tools using transparent trust metadata before an Agent calls them

The production service is public, read-only by default, actively maintained, and currently exposes 12 tools over Streamable HTTP. The npm bridge supports stdio-only clients without an account or API key and generates a random non-personal Agent ID per installation. `--source awesome-mcp-devops` is only a safe aggregate channel label.