### PR TITLE
Add SandBase Harness MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ Self-hosted control plane for deploying and operating OpenClaw and Hermes agent 
 | **What it does** | Deploys agent runtimes, controls their lifecycle, and exposes fleet status, metrics, events, and per-agent cost through MCP. |
 | **Note** | 🛡️ Destructive deletion is disabled unless explicitly enabled. |
 
+### SandBase Harness
+
+Self-hosted MCP bridge for persistent agent sessions and backend-selectable execution sandboxes.
+
+| | |
+|---|---|
+| **Repo** | [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) |
+| **Maintainer** | 👥 Community |
+| **Docs** | [Installation and MCP configuration](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md) |
+| **What it does** | Exposes session, artifact, and lifecycle tools for agent workflows; supports local, Docker, Kubernetes, and self-hosted Worker sandbox backends. |
+| **Note** | 🛡️ Isolation properties depend on the selected backend and deployment configuration. |
+
 ### Portainer
 
 | | |


### PR DESCRIPTION
Add SandBase Harness to the Kubernetes and Containers section.

- Repository: https://github.com/sandbaseai/sandbase-harness
- Current release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
- Installation/MCP configuration: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md
- Sandbox backend details: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/usage.md#sandbox-backends
- `git diff --check` passes.

The entry is a factual description of the MCP bridge and its DevOps-relevant local, Docker, Kubernetes, and self-hosted Worker backends. I maintain/contribute to SandBase Harness and disclose that relationship. Isolation properties depend on the selected backend and deployment configuration.
