### PR TITLE
Update Star History chart for light and dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=WagnerAgent/awesome-mcp-servers-devops&type=date&legend=top-left)](https://www.star-history.com/#WagnerAgent/awesome-mcp-servers-devops&type=date&legend=top-left)
+<a href="https://www.star-history.com/?type=date&legend=top-left&repos=WagnerAgent%2Fawesome-mcp-servers-devops">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=WagnerAgent/awesome-mcp-servers-devops&type=date&theme=dark&legend=top-left&sealed_token=yBLCtv_DrWnlNKY5w3yt4hPyAPGZm1SpyeajjiZrZnZZFvXFdS8T-pWMSy7SG7kGUHqoNJfPHgQWzinCfbbDe9mc9E2ECp3F-9paUP_sWtjELR-RJyULS8Wtc9-TnKtf2VKoLCTKsZjFA4HFHJGp_yyUpHIHikz3n6LhyLmv8tCeaOa19Bee-BcBMxrh" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=WagnerAgent/awesome-mcp-servers-devops&type=date&legend=top-left&sealed_token=yBLCtv_DrWnlNKY5w3yt4hPyAPGZm1SpyeajjiZrZnZZFvXFdS8T-pWMSy7SG7kGUHqoNJfPHgQWzinCfbbDe9mc9E2ECp3F-9paUP_sWtjELR-RJyULS8Wtc9-TnKtf2VKoLCTKsZjFA4HFHJGp_yyUpHIHikz3n6LhyLmv8tCeaOa19Bee-BcBMxrh" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=WagnerAgent/awesome-mcp-servers-devops&type=date&legend=top-left&sealed_token=yBLCtv_DrWnlNKY5w3yt4hPyAPGZm1SpyeajjiZrZnZZFvXFdS8T-pWMSy7SG7kGUHqoNJfPHgQWzinCfbbDe9mc9E2ECp3F-9paUP_sWtjELR-RJyULS8Wtc9-TnKtf2VKoLCTKsZjFA4HFHJGp_yyUpHIHikz3n6LhyLmv8tCeaOa19Bee-BcBMxrh" />
+  </picture>
+</a>
 
 ## Contents
 


### PR DESCRIPTION
## Summary

- replace the legacy Star History Markdown image with a `<picture>` block
- use the supplied dark-theme chart when GitHub is in dark mode
- use the supplied light chart otherwise
- update the click-through URL to the current Star History route

## Validation

- both chart endpoints return HTTP 200 with `image/svg+xml`
- the click-through URL returns HTTP 200
- `git diff --check` passes