### PR TITLE
Add Cohesivity MCP to cloud platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,18 @@ Comprehensive coverage of Cloudflare's platform.
 | **What it does** | ECS, Cloud Monitor, OOS operations. |
 | **Also available** | 📦 [ACK (Kubernetes)](https://github.com/aliyun/alibabacloud-ack-mcp-server), [DataWorks](https://github.com/aliyun/alibabacloud-dataworks-mcp-server), [DMS](https://github.com/aliyun/alibabacloud-dms-mcp-server), [Function Compute](https://github.com/aliyun/alibabacloud-fc-mcp-server). |
 
+### Cohesivity
+
+cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.
+
+| | |
+|---|---|
+| **Repo** | [cohesivity-org/cohesivity-plugin](https://github.com/cohesivity-org/cohesivity-plugin) |
+| **Maintainer** | Cohesivity (Official) |
+| **What it does** | Provision and manage backend infrastructure through local and remote MCP tools. |
+| **Docs** | [Installation and client packages](https://github.com/cohesivity-org/cohesivity-plugin#readme) |
+| **Requires** | Node.js for the local MCP; OAuth sign-in for the remote management MCP at `https://cohesivity.ai/mcp/manage`. |
+
 ### Other Platforms
 
 | Repo | Notes |


### PR DESCRIPTION
Adds Cohesivity under Cloud Platforms using the description-plus-details-table format in CONTRIBUTING.md.

cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.

The entry includes the official public repository, installation documentation, and explicit requirements: Node.js for the local project MCP, OAuth for remote management. Anonymous tenant provisioning is local; the remote endpoint is not an unauthenticated provisioning service.

The placement reflects backend and infrastructure operations. The change follows the documented table format and the factual source/installation disclosure in merged SandBase Harness PR #75. Plugin and skill installation remains documented in the linked source rather than duplicated as separate MCP entries.

Checked the public manifests and source documentation, duplicate entries/PRs, table structure, exact description, and `git diff --check`. A non-mutating GET to the remote endpoint returned 405 with `Allow: POST, OPTIONS`; this confirms route reachability, not an authenticated MCP session.

I maintain Cohesivity.
